### PR TITLE
Add volumeBindingMode to ebs-sc StorageClass

### DIFF
--- a/eks/deploy-db-python.yaml
+++ b/eks/deploy-db-python.yaml
@@ -35,6 +35,9 @@ spec:
       containers:
       - name: db
         image: postgres:13
+        env:
+        - name: PGDATA # This is required due to 
+          value: /var/lib/postgresql/data/pgdata
         envFrom:
         - secretRef:
             name: fastapi-secret
@@ -43,13 +46,22 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/postgresql/data
           name: postgres-data
+        - mountPath: /docker-entrypoint-initdb.d
+          name: db-init-script
         resources:
           requests:
-            cpu: "50m"
-            memory: "50Mi"
+            cpu: "100m"
+            memory: "100Mi"
           limits:
-            cpu: "250m"
-            memory: "250Mi"
+            cpu: "500m"
+            memory: "500Mi"
+      volumes:
+      - configMap:
+          items:
+          - key: init.sh
+            path: init.sh
+          name: db-init-script
+        name: db-init-script
   volumeClaimTemplates:
   - metadata:
       name: postgres-data

--- a/kubernetes/postgres-db.yaml
+++ b/kubernetes/postgres-db.yaml
@@ -28,15 +28,19 @@ spec:
       containers:
       - name: db
         image: postgres:13
+        env:
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         envFrom:
         - secretRef:
-            name: fastapi-secret # Create kubernetes secret in advance using .env file
+            name: fastapi-secret
+        ports:
+        - containerPort: 5432
         volumeMounts:
-        - mountPath: /docker-entrypoint-initdb.d/init.sh
-          name: db-init-script
-          subPath: init.sh
         - mountPath: /var/lib/postgresql/data
           name: postgres-data
+        - mountPath: /docker-entrypoint-initdb.d
+          name: db-init-script
         resources:
           requests:
             cpu: "100m"
@@ -45,20 +49,15 @@ spec:
             cpu: "500m"
             memory: "500Mi"
       volumes:
-      - name: db-init-script
-        configMap:
-          name: db-init-script # Create kubernetes config map in advance using init.sh file
+      - configMap:
+          items:
+          - key: init.sh
+            path: init.sh
+          name: db-init-script
+        name: db-init-script
       - name: postgres-data
         persistentVolumeClaim:
           claimName: postgres-pvc
-  volumeClaimTemplates:
-  - metadata:
-      name: postgres-data
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 1Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
*Issue #, if available:* #6

*Description of changes:*

Updates the StorageClass used for the EBS CSI driver to set `volumeBindingMode: WaitForFirstConsumer`. This ensures that the EBS volume created in the correct AZ by waiting until after the postgres pod is created and scheduled to a node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
