### PR TITLE
Add cert-manager namespace to Fargate profile

### DIFF
--- a/eks/create-fargate-python.yaml
+++ b/eks/create-fargate-python.yaml
@@ -18,6 +18,7 @@ fargateProfiles:
       - namespace: default
       - namespace: kube-system
       - namespace: my-cool-app
+      - namespace: cert-manager
 
 # The IAM section is for managing IAM roles and service accounts for your cluster.
 iam:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adds the `cert-manager` namespace to the `fp-default` Fargate profile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
