### PR TITLE
Remove AWS credentials from file .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,12 +17,8 @@ POSTGRES_VOLUME=db
 # USE WITH DOCKER ENVIRONMENT
 DOCKER_DATABASE_URL=postgresql://bookdbadmin:dbpassword@db:5432/bookstore
 
-# AWS CREDENTIALS
-# Run "aws sts get-caller-identity" to get your account id
-# Run "aws configure" to setup your credentials
-AWS_ACCOUNT_ID=012345678901
-AWS_ACCESS_KEY_ID=ASIAWNZPPVHEXAMPLE
-AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE
+# AWS 
+AWS_ACCOUNT_ID=012345678901EXAMPLE
 AWS_REGION=us-west-2
 
 # DOCKER 


### PR DESCRIPTION
*Issue #, if available:*

AWS credentials are stored in .env file

*Description of changes:*

Remove AWS credentials from .env.example file.
The user will configure aws credentials in the terminal using other methods, such as aws configure, instance role, preferably using IAM roles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
