### PR TITLE
feat: Update to EKS 1.29

### DIFF
--- a/eks/create-fargate-python.yaml
+++ b/eks/create-fargate-python.yaml
@@ -6,9 +6,9 @@ metadata:
   # name: The name of your EKS cluster.
   name: fargate-quickstart
   # region: The AWS region where your EKS cluster will be created.
-  region: us-west-2
+  region: us-east-1
   # version: The Kubernetes version to use for your EKS cluster.
-  version: "1.26"
+  version: "1.29"
 
 # The fargateProfiles section is for configuring Fargate profiles, which determine which pods run on Fargate when launched into specified namespaces.
 fargateProfiles:

--- a/eks/create-mng-python.yaml
+++ b/eks/create-mng-python.yaml
@@ -7,9 +7,9 @@ metadata:
   # name: The name of your EKS cluster.
   name: managednode-quickstart
   # region: The AWS region where your EKS cluster will be created.
-  region: us-west-2
+  region: us-east-1
   # version: The Kubernetes version to use for your EKS cluster.
-  version: "1.26"
+  version: "1.29"
 
 # The IAM section is for managing IAM roles and service accounts for your cluster.
 iam:

--- a/eks/deploy-app-python.yaml
+++ b/eks/deploy-app-python.yaml
@@ -49,10 +49,10 @@ metadata:
   name: fastapi-ingress
   namespace: my-cool-app
   annotations:
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
 spec:
+  ingressClassName: alb
   rules:
   - http:
       paths:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

1. Updates cluster templates to use 1.29 instead of 1.26
2. Updates application ingress manifest to use `spec.ingressClassName` instead of an annotation as this has been deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
