### PR TITLE
Update Dockerfile to use python:3.9-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-slim-buster as builder
+FROM python:3.9-slim as builder
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -12,7 +12,7 @@ WORKDIR /server
 COPY ./server/requirements.txt /server/
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /server/wheels -r requirements.txt
 
-FROM python:3.9-slim-buster as runner
+FROM python:3.9-slim  as runner
 
 WORKDIR /server
 


### PR DESCRIPTION
*Issue*
DNS resolution bug exists 
*Description of changes:*
Updating the Dockerfile to use python:3.9-slim with the newer Debian release (Bullseye/Bookworm) fixes identified issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
