### PR TITLE
Update eksctl templates to use Kubernetes 1.34

### DIFF
--- a/eks/create-fargate-python.yaml
+++ b/eks/create-fargate-python.yaml
@@ -8,7 +8,7 @@ metadata:
   # region: The AWS region where your EKS cluster will be created.
   region: us-east-1
   # version: The Kubernetes version to use for your EKS cluster.
-  version: "1.29"
+  version: "1.34"
 
 # The fargateProfiles section is for configuring Fargate profiles, which determine which pods run on Fargate when launched into specified namespaces.
 fargateProfiles:

--- a/eks/create-mng-python.yaml
+++ b/eks/create-mng-python.yaml
@@ -9,7 +9,7 @@ metadata:
   # region: The AWS region where your EKS cluster will be created.
   region: us-east-1
   # version: The Kubernetes version to use for your EKS cluster.
-  version: "1.29"
+  version: "1.34"
 
 # The IAM section is for managing IAM roles and service accounts for your cluster.
 iam:


### PR DESCRIPTION
*Issue #30*

*Description of changes:*

Updated eksctl cluster templates to use Kubernetes version 1.34 (from 1.29). The original issue requested an upgrade to 1.30, but since that version is now in EKS extended support (end of life July 2026), we upgraded to 1.34 which is in standard support until December 2026.

**Files changed:**
- `eks/create-mng-python.yaml` — managed node group template
- `eks/create-fargate-python.yaml` — Fargate profile template

**Testing:**
- Local app build and run verified with `podman compose` (HTTP 200 at localhost:8000)
- `eksctl create cluster --dry-run` passed on both templates with eksctl 0.224.0, confirming valid config and Kubernetes 1.34 support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


