### PR TITLE
Fix Dependabot alerts: bump FastAPI 0.135.3, starlette 0.49.1, python…

### DIFF
--- a/server/aws-secrets/requirements.txt
+++ b/server/aws-secrets/requirements.txt
@@ -1,9 +1,9 @@
-fastapi~=0.115.5
+fastapi~=0.135.3
 uvicorn~=0.32.0
 sqlalchemy~=2.0.36
 psycopg2-binary~=2.9.10
 pydantic~=2.9.2
-starlette~=0.41.2
+starlette~=0.49.1
 jinja2~=3.1.4
-python-multipart~=0.0.17
+python-multipart~=0.0.26
 boto3~=1.28

--- a/server/general/requirements.txt
+++ b/server/general/requirements.txt
@@ -1,8 +1,8 @@
-fastapi~=0.115.5
+fastapi~=0.135.3
 uvicorn~=0.32.0
 sqlalchemy~=2.0.36
 psycopg2-binary~=2.9.10
 pydantic~=2.9.2
-starlette~=0.41.2
+starlette~=0.49.1
 jinja2~=3.1.4
-python-multipart~=0.0.17
+python-multipart~=0.0.26

--- a/server/opentelemetry/requirements.txt
+++ b/server/opentelemetry/requirements.txt
@@ -1,11 +1,11 @@
-fastapi~=0.115.5
+fastapi~=0.135.3
 uvicorn~=0.32.0
 sqlalchemy~=2.0.36
 psycopg2-binary~=2.9.10
 pydantic~=2.9.2
-starlette~=0.41.2
+starlette~=0.49.1
 jinja2~=3.1.4
-python-multipart~=0.0.17
+python-multipart~=0.0.26
 opentelemetry-distro
 opentelemetry-exporter-otlp
 opentelemetry-api


### PR DESCRIPTION
…-multipart 0.0.26

Resolves:
- CVE-2025-62727: Starlette O(n^2) DoS via Range header merging in FileResponse (High)
- CVE-2025-54121: Starlette DoS via large files in multipart forms (Moderate)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
