### PR TITLE
fix: Upgrade starlette and fastapi to resolve 4 security CVEs

### DIFF
--- a/server/aws-secrets/requirements.txt
+++ b/server/aws-secrets/requirements.txt
@@ -1,9 +1,9 @@
-fastapi~=0.135.3
+fastapi==0.139.2
 uvicorn~=0.32.0
 sqlalchemy~=2.0.36
 psycopg2-binary~=2.9.10
 pydantic~=2.9.2
-starlette~=0.49.1
+starlette==1.3.1
 jinja2~=3.1.4
 python-multipart~=0.0.26
 boto3~=1.28

--- a/server/general/requirements.txt
+++ b/server/general/requirements.txt
@@ -1,8 +1,8 @@
-fastapi~=0.135.3
+fastapi==0.139.2
 uvicorn~=0.32.0
 sqlalchemy~=2.0.36
 psycopg2-binary~=2.9.10
 pydantic~=2.9.2
-starlette~=0.49.1
+starlette==1.3.1
 jinja2~=3.1.4
 python-multipart~=0.0.26

--- a/server/opentelemetry/requirements.txt
+++ b/server/opentelemetry/requirements.txt
@@ -1,9 +1,9 @@
-fastapi~=0.135.3
+fastapi==0.139.2
 uvicorn~=0.32.0
 sqlalchemy~=2.0.36
 psycopg2-binary~=2.9.10
 pydantic~=2.9.2
-starlette~=0.49.1
+starlette==1.3.1
 jinja2~=3.1.4
 python-multipart~=0.0.26
 opentelemetry-distro


### PR DESCRIPTION
## Summary

Upgrades `fastapi` from `~=0.135.3` to `==0.139.2` and `starlette` from `~=0.49.1` to `==1.3.1` across all 3 server requirement files.

## Security Fixes

| CVE | Severity | Description | Fixed in |
|-----|----------|-------------|----------|
| CVE-2026-54283 | **High** (7.5) | `request.form()` limits silently ignored for urlencoded forms → DoS | starlette ≥ 1.3.1 |
| CVE-2026-48818 | **High** (7.5) | SSRF/NTLM credential theft via UNC paths in StaticFiles (Windows) | starlette ≥ 1.1.0 |
| CVE-2026-48817 | **Medium** (5.3) | Arbitrary HTTP method dispatched to HTTPEndpoint via getattr | starlette ≥ 1.1.0 |
| CVE-2026-48710 | **Medium** (6.5) | Missing Host header validation → path poisoning bypass | starlette ≥ 1.0.1 |

## Why Dependabot couldn't auto-fix

Dependabot couldn't create a PR because `fastapi~=0.135.3` pins starlette to `~=0.49.x` via its own dependency constraints. Upgrading starlette to 1.x required also bumping fastapi to a version that supports it (0.139.2, which requires `starlette>=0.46.0` with no upper bound).

## Testing

- [x] `pip install --dry-run` confirms all dependencies resolve without conflicts
- [x] `docker compose build` succeeds with the new versions

## Files Changed

- `server/general/requirements.txt`
- `server/aws-secrets/requirements.txt`
- `server/opentelemetry/requirements.txt`