### PR TITLE
fix: Remove hardcoded RDS credentials from CloudFormation template

### DIFF
--- a/eks/rds-serverless-postgres.json
+++ b/eks/rds-serverless-postgres.json
@@ -8,6 +8,21 @@
             "Type": "String",
             "AllowedValues": ["ManagedNodeGroup", "AutoMode"],
             "ConstraintDescription": "Must specify either Managed Node Groups or AutoMode"
+        },
+        "DBMasterUsername": {
+            "Description": "Master username for the RDS cluster",
+            "Default": "bookdbadmin",
+            "Type": "String",
+            "MinLength": 1,
+            "MaxLength": 63
+        },
+        "DBMasterPassword": {
+            "Description": "Master password for the RDS cluster",
+            "Type": "String",
+            "NoEcho": true,
+            "MinLength": 8,
+            "MaxLength": 128,
+            "ConstraintDescription": "Must be between 8 and 128 characters"
         }
     },
     "Conditions": {
@@ -22,8 +37,8 @@
                 "DBSubnetGroupName": {"Ref": "DBSubnetGroup"},
                 "Engine": "aurora-postgresql",
                 "EngineVersion": "15.10",
-                "MasterUsername": "bookdbadmin",
-                "MasterUserPassword": "dbpassword",
+                "MasterUsername": {"Ref": "DBMasterUsername"},
+                "MasterUserPassword": {"Ref": "DBMasterPassword"},
                 "Port": 5432,
                 "ServerlessV2ScalingConfiguration": {
                     "MinCapacity": 0.5,


### PR DESCRIPTION
## Summary

Resolves ACAT finding [c6581008-92ea-4dc0-90fc-43f9649beb63](https://appsec.corp.amazon.com/talos/finding/c6581008-92ea-4dc0-90fc-43f9649beb63/group) — hardcoded credentials in `eks/rds-serverless-postgres.json`.

## Changes

- Replaced hardcoded `MasterUsername: "bookdbadmin"` with a `DBMasterUsername` parameter (default preserved for workshop compatibility)
- Replaced hardcoded `MasterUserPassword: "dbpassword"` with a `DBMasterPassword` parameter using `NoEcho: true`
- Password is now required at deploy time — no default, so it can't accidentally leak

## Impact

Workshop users will now need to provide a password when deploying the stack:
```bash
aws cloudformation deploy --template-file eks/rds-serverless-postgres.json \
  --stack-name eksdevworkshop-rds \
  --parameter-overrides DBMasterPassword=<your-secure-password>
```

## Remaining branches with the old code

After merging to main, these remote branches still carry the hardcoded password and should be cleaned up:
- `feat/eks-auto-mode-karpenter`
- `aws-opentelemetry`
- `aws-secrets-manager-lab`
- `jrgwv-patch-1`
- `smrutiranjantripathy-patch-1`
- `30-update-eksctl-templates-to-use-130`

Consider deleting stale branches to fully close the ACAT finding.